### PR TITLE
Add option to suppress SessionStart message in non-Warp terminals

### DIFF
--- a/plugins/warp/scripts/on-session-start.sh
+++ b/plugins/warp/scripts/on-session-start.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Hook script for Claude Code SessionStart event
 # Shows welcome message and Warp detection status
+#
+# Set CLAUDE_CODE_WARP_QUIET_SESSION_START=1 to suppress this message.
+# Useful when running in non-Warp terminals that support OSC 777
+# notifications (e.g. Ghostty), where the plugin works but the
+# "not running in Warp" message is misleading.
+
+[ "$CLAUDE_CODE_WARP_QUIET_SESSION_START" = "1" ] && exit 0
 
 # Check if running in Warp terminal
 if [ "$TERM_PROGRAM" = "WarpTerminal" ]; then


### PR DESCRIPTION
## Problem

The SessionStart hook displays an "ℹ️ Warp plugin installed but you're not running in Warp terminal" message every time Claude Code starts in a non-Warp terminal.

However, the plugin's notifications (OSC 777) work in **any terminal that supports OSC 777** — not just Warp. For example, [Ghostty](https://ghostty.org/) fully supports OSC 777, and the plugin's Stop and Notification hooks work correctly there. The message is misleading for these users and clutters the session start output.

## Solution

Add a `CLAUDE_CODE_WARP_QUIET_SESSION_START=1` environment variable check that suppresses the message when set. This gives users who intentionally run the plugin in non-Warp terminals a clean way to opt out of the banner without modifying the plugin.

### Usage

```bash
# In shell profile (.zshrc, .bashrc, etc.)
export CLAUDE_CODE_WARP_QUIET_SESSION_START=1
```

The default behavior is unchanged — users who don't set the variable see the same messages as before.