### PR TITLE
remove unnecessary strict field from plugin json

### DIFF
--- a/plugins/warp/.claude-plugin/plugin.json
+++ b/plugins/warp/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
     "name": "Warp",
     "url": "https://warp.dev"
   },
-  "homepage": "https://github.com/warpdotdev/claude-code-warp",
-  "strict": false
+  "homepage": "https://github.com/warpdotdev/claude-code-warp"
 }


### PR DESCRIPTION
We've received some reports that the inclusion of this field breaks the plugin for some older claude versions. This should be fixed by updating claude, but it also seems like (through testing and research) this field is unnecessary, so we can just remove it for maximal compatibility.

This addresses this issue: https://github.com/warpdotdev/claude-code-warp/issues/10