### PR TITLE
fix: TTY detection for hook subprocesses

### DIFF
--- a/plugins/warp/scripts/warp-notify.sh
+++ b/plugins/warp/scripts/warp-notify.sh
@@ -17,5 +17,19 @@ TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+# Hook subprocesses spawned by Claude Code may lack a controlling terminal,
+# so /dev/tty is unavailable. Walk the parent process chain to find the actual
+# TTY device and write there instead.
+TTY_DEVICE=""
+current_pid=$PPID
+for _ in 1 2 3 4 5; do
+    t=$(ps -o tty= -p "$current_pid" 2>/dev/null | tr -d ' ')
+    if [ -n "$t" ] && [ "$t" != "??" ]; then
+        TTY_DEVICE="/dev/$t"
+        break
+    fi
+    current_pid=$(ps -o ppid= -p "$current_pid" 2>/dev/null | tr -d ' ')
+    [ -z "$current_pid" ] && break
+done
+
+printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > "${TTY_DEVICE:-/dev/tty}" 2>/dev/null || true


### PR DESCRIPTION
## Problem

Hook subprocesses spawned by Claude Code lack a controlling terminal, so  is unavailable. This caused notifications to fail silently — they appeared inconsistently or not at all.

## Solution

Walk the parent process chain to find the actual TTY device and write the OSC 777 sequence there instead of relying on .

### Changes

- Modified `warp-notify.sh` to traverse the process tree (PPID chain) to locate the actual TTY device
- Falls back to `/dev/tty` if no TTY is found (preserves backward compatibility)

### Testing

- Verified TTY detection finds `/dev/ttys008` from the parent process
- Confirmed OSC 777 notifications reach Warp when written to the correct TTY
- Script remains idempotent and backward compatible

## Checklist

- [x] Fix tested locally
- [x] Backward compatible fallback to /dev/tty