### PR TITLE
Add WARP_PLUGIN_DISABLE_PROJECT env var to skip project field

### DIFF
--- a/plugins/warp/scripts/build-payload.sh
+++ b/plugins/warp/scripts/build-payload.sh
@@ -39,8 +39,11 @@ build_payload() {
     local session_id cwd project
     session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
     cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null)
+    # Allow users to suppress the auto-derived project field so Warp doesn't
+    # override a tab name that the user (or another tool) has set explicitly.
+    # Set WARP_PLUGIN_DISABLE_PROJECT=1 to opt out.
     project=""
-    if [ -n "$cwd" ]; then
+    if [ -n "$cwd" ] && [ -z "${WARP_PLUGIN_DISABLE_PROJECT:-}" ]; then
         project=$(basename "$cwd")
     fi
 


### PR DESCRIPTION
## Summary
Adds an opt-in env var, `WARP_PLUGIN_DISABLE_PROJECT=1`, that causes `build-payload.sh` to omit the auto-derived `project` field from the payload sent to Warp.

## Motivation
Every hook (prompt_submit, post_tool_use, session_start, stop, notification, permission_request) sends `project = basename(cwd)` to Warp via OSC 777. Warp uses that value to label the CLI agent's tab.

That's a sensible default, but it fights with users who rename their tab explicitly — for example via a tool that sets the tab title through OSC escapes, or a tmux/terminal title they've set by hand. Because the plugin fires on every prompt, it re-asserts `project` and clobbers the user's title within a second or two.

There's currently no way to opt out without forking the plugin. An env var gate is the smallest possible change and keeps the default behavior identical for everyone who doesn't set it.

## Change
One conditional in `plugins/warp/scripts/build-payload.sh`. If `WARP_PLUGIN_DISABLE_PROJECT` is set (to any non-empty value), `project` stays empty and Warp falls back to whatever title is already on the tab.

## Test plan (not yet run — suggested verification)
- [ ] With env var unset: payload still contains `project = basename(cwd)` (default behavior unchanged).
- [ ] With `WARP_PLUGIN_DISABLE_PROJECT=1`: payload's `project` field is empty; a tab title set via other means is no longer overridden on subsequent prompts.

Happy to adjust the env var name, add tests in `tests/test-hooks.sh`, or add docs if you'd prefer a different convention.