### PR TITLE
add resume conversation hook

### DIFF
--- a/plugins/warp/hooks/hooks.json
+++ b/plugins/warp/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup",
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
If you start a claude conversation with `claude --resume <id>`, we should still register a session listener for that conversation