### PR TITLE
Quote ${CLAUDE_PLUGIN_ROOT} in hooks.json so paths with spaces work

### DIFF
--- a/plugins/warp/hooks/hooks.json
+++ b/plugins/warp/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-session-start.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-session-start.sh\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.sh\""
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-notification.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-notification.sh\""
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-permission-request.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-permission-request.sh\""
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh\""
           }
         ]
       }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-post-tool-use.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-post-tool-use.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

On Windows (or any platform where the plugin directory path contains a space), every hook in `plugins/warp/hooks/hooks.json` fails because `${CLAUDE_PLUGIN_ROOT}` is expanded into the `command` string **without quotes**. The shell word-splits the resulting path on the space and tries to execute the first token as a command.

## Repro

- Windows account whose username has a space, e.g. `C:\Users\First Last`
- Install Claude Code and enable `warp@claude-code-warp`
- Submit any prompt

## Observed

```
UserPromptSubmit operation blocked by hook:
[${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh]:
/c/Users/First: line 1: syntax error near unexpected token `('
/c/Users/First: line 1: `[9ADC:4BD8][...]i001: Burn v3.14.1.8722, Windows v10.0 (Build 26200: Service Pack 0), path: C:\WINDOWS\Temp\{...}\.cr\VC_redist.x86.exe'
```

The path `/c/Users/First Last/.claude/plugins/cache/claude-code-warp/warp/2.0.0/scripts/on-prompt-submit.sh` is split into `/c/Users/First` + `Last/...`. Since that truncated path isn't an executable, the shell falls through and ends up interpreting unrelated bytes on disk (in my case a stray VC_redist bootstrapper log) as a script, producing a confusing syntax error.

All six hooks are affected: `SessionStart`, `Stop`, `Notification`, `PermissionRequest`, `UserPromptSubmit`, `PostToolUse`.

## Root cause

Each hook is registered as:

```json
"command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh"
```

When Claude Code hands the expanded string to the shell, there are no quotes, so any whitespace in the path breaks word-splitting. The scripts themselves already quote `"$SCRIPT_DIR"` correctly — the issue is purely at the registration layer.

## Fix

Wrap each `command` value in embedded double quotes so the shell sees a quoted path after expansion:

```diff
-"command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh"
+"command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh\""
```

Applied to all six hook entries. No behavioural change for users whose paths don't contain spaces.

## Verification

Tested locally on `C:\Users\Kshitij Shah\...` — prompt submission, session start/stop, notifications, permission requests, and post-tool-use events all fire correctly after the change. JSON still parses cleanly.
