### PR TITLE
Add IPC fallback for Warp notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The plugin communicates with Warp via OSC 777 escape sequences. Each hook script
 
 Payloads include a protocol version negotiated between the plugin and Warp (`min(plugin_version, warp_version)`), the session ID, working directory, and event-specific fields.
 
+When Warp exports `WARP_CLI_AGENT_IPC`, the notification scripts send the OSC payload over that Unix socket instead of writing to `/dev/tty`. Older Warp builds keep using the terminal fallback.
+
 The plugin registers six hooks:
 - **SessionStart** — emits the plugin version and a welcome system message
 - **Stop** — reads the transcript to extract your prompt and Claude's response, then sends a task-complete notification

--- a/plugins/warp/scripts/legacy/warp-notify.sh
+++ b/plugins/warp/scripts/legacy/warp-notify.sh
@@ -6,5 +6,11 @@ TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+OSC_PAYLOAD=$(printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY")
+
+if [ -n "${WARP_CLI_AGENT_IPC:-}" ]; then
+    (printf "%s" "$OSC_PAYLOAD" | nc -U "$WARP_CLI_AGENT_IPC") 2>/dev/null || true
+else
+    # Write directly to /dev/tty to ensure it reaches the terminal.
+    (printf "%s" "$OSC_PAYLOAD" > /dev/tty) 2>/dev/null || true
+fi

--- a/plugins/warp/scripts/warp-notify.sh
+++ b/plugins/warp/scripts/warp-notify.sh
@@ -17,5 +17,11 @@ TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+OSC_PAYLOAD=$(printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY")
+
+if [ -n "${WARP_CLI_AGENT_IPC:-}" ]; then
+    (printf "%s" "$OSC_PAYLOAD" | nc -U "$WARP_CLI_AGENT_IPC") 2>/dev/null || true
+else
+    # Write directly to /dev/tty to ensure it reaches the terminal.
+    (printf "%s" "$OSC_PAYLOAD" > /dev/tty) 2>/dev/null || true
+fi


### PR DESCRIPTION
Teach the Warp Claude Code plugin to prefer WARP_CLI_AGENT_IPC when present and fall back to /dev/tty otherwise. This keeps notifications working with newer Claude Code builds that no longer grant hooks terminal access.