### PR TITLE
Add AskUserQuestion hook

### DIFF
--- a/plugins/warp/hooks/hooks.json
+++ b/plugins/warp/hooks/hooks.json
@@ -62,6 +62,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-ask-user-question.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/warp/scripts/on-ask-user-question.sh
+++ b/plugins/warp/scripts/on-ask-user-question.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Hook script for Claude Code PreToolUse event on AskUserQuestion
+# Sends a structured Warp notification when Claude asks the user a question,
+# transitioning the session status to Blocked until the user answers.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/should-use-structured.sh"
+
+# No legacy equivalent for this hook
+if ! should_use_structured; then
+    exit 0
+fi
+
+source "$SCRIPT_DIR/build-payload.sh"
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# AskUserQuestion supports 1-4 questions. Surface the first question's text as
+# the notification summary; if Claude asks more than one in the same call,
+# answering any of them unblocks the session.
+SUMMARY=$(echo "$INPUT" | jq -r '.tool_input.questions[0].question // "Claude is asking a question"' 2>/dev/null)
+
+# Truncate for notification display
+if [ -n "$SUMMARY" ] && [ ${#SUMMARY} -gt 200 ]; then
+    SUMMARY="${SUMMARY:0:197}..."
+fi
+
+BODY=$(build_payload "$INPUT" "question_asked" \
+    --arg summary "$SUMMARY")
+
+"$SCRIPT_DIR/warp-notify.sh" "warp://cli-agent" "$BODY"

--- a/plugins/warp/tests/test-hooks.sh
+++ b/plugins/warp/tests/test-hooks.sh
@@ -218,7 +218,7 @@ assert_eq "legacy Warp shows active message" \
 echo ""
 echo "--- Modern-only hooks exit silently without protocol version ---"
 
-for HOOK in on-permission-request.sh on-prompt-submit.sh on-post-tool-use.sh; do
+for HOOK in on-permission-request.sh on-prompt-submit.sh on-post-tool-use.sh on-ask-user-question.sh; do
     echo '{}' | bash "$HOOK_DIR/$HOOK" 2>/dev/null
     assert_eq "$HOOK exits 0 without protocol version" "0" "$?"
 done


### PR DESCRIPTION
## Summary
- Wires a `PreToolUse` hook matched to `AskUserQuestion` so Claude pausing to ask the user a question triggers a Warp notification.
- Reuses the existing `question_asked` event already defined in Warp's CLI agent protocol (`CLIAgentEventType::QuestionAsked`, mapped to `Blocked` status in `cli_agent_sessions/mod.rs`) — no Warp-side change needed.
- New script follows the same pattern as `on-permission-request.sh`: extracts the first question's text as `summary`, truncates to 200 chars, sends via `warp-notify.sh`.

## Motivation
`AskUserQuestion` is one of the most frequent ways Claude blocks waiting for the user, but it currently produces no Warp notification. Users running Claude in the background miss prompts entirely unless they're already focused on the Warp pane. The Warp side has supported the `question_asked` event since v1 of the protocol — the plugin just hasn't been emitting it.

## Test plan
- [x] `tests/test-hooks.sh` passes (40/40, including new silent-exit assertion for the script)
- [x] Manual payload inspection — `build_payload` produces:
  ```json
  {"v":1,"agent":"claude","event":"question_asked","session_id":"abc","cwd":"/tmp/foo","project":"foo","summary":"Which option do you prefer?"}
  ```
  which matches the shape `v1::parse` expects in `event/v1.rs`.
- [ ] End-to-end test in Warp (would appreciate a maintainer running this — I can confirm payload + OSC emission but can't reproduce the full Warp UI loop locally).