### PR TITLE
fix: deliver OSC notifications when hooks have no controlling tty

### DIFF
--- a/plugins/warp/scripts/find-controlling-tty.sh
+++ b/plugins/warp/scripts/find-controlling-tty.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Emit candidate controlling-tty paths by walking up the process tree.
+#
+# Background: when the hook runs inside a sandbox that detaches the subprocess
+# from its controlling terminal (e.g. Claude Code's macOS `sandbox-exec`
+# wrapper for Bash tool calls, when `sandbox.enabled` is set), the hook has
+# no controlling terminal — opening `/dev/tty` returns ENXIO. To still deliver
+# the OSC notification, we walk up the process tree and emit each ancestor's
+# tty device path; the caller tries to write to each in turn until one
+# succeeds.
+#
+# Caveats:
+# - We do not verify the ancestor is actually Warp. In nested setups (tmux,
+#   screen, ssh into non-Warp), the OSC may end up in a terminal that ignores
+#   it. OSC 777 is widely ignored by terminals that don't implement it, so
+#   the worst case is a silently dropped notification — not corruption.
+# - The walk is depth-limited to bound the number of `ps` invocations.
+
+find_candidate_ttys() {
+    local pid=$PPID
+    local depth=0
+    while [[ -n $pid && $pid != 0 && $pid != 1 && $depth -lt 20 ]]; do
+        local tty
+        tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+        if [[ -n $tty && $tty != "??" ]]; then
+            printf '/dev/%s\n' "$tty"
+        fi
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        depth=$((depth + 1))
+    done
+}

--- a/plugins/warp/scripts/legacy/warp-notify.sh
+++ b/plugins/warp/scripts/legacy/warp-notify.sh
@@ -2,9 +2,24 @@
 # Warp notification utility using OSC escape sequences
 # Usage: warp-notify.sh <title> <body>
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../find-controlling-tty.sh"
+
 TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+emit() {
+    printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > "$1" 2>/dev/null
+}
+
+# Prefer /dev/tty. If unopenable (e.g. the hook is running inside a sandbox
+# that detached the subprocess from its controlling terminal), fall back to
+# trying each ancestor process's tty in turn until one accepts the write.
+emit /dev/tty && exit 0
+
+while read -r tty; do
+    emit "$tty" && exit 0
+done < <(find_candidate_ttys)
+
+exit 0

--- a/plugins/warp/scripts/warp-notify.sh
+++ b/plugins/warp/scripts/warp-notify.sh
@@ -7,6 +7,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/should-use-structured.sh"
+source "$SCRIPT_DIR/find-controlling-tty.sh"
 
 # Only emit notifications when we've confirmed the Warp build can render them.
 if ! should_use_structured; then
@@ -17,5 +18,17 @@ TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+emit() {
+    printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > "$1" 2>/dev/null
+}
+
+# Prefer /dev/tty. If unopenable (e.g. the hook is running inside a sandbox
+# that detached the subprocess from its controlling terminal), fall back to
+# trying each ancestor process's tty in turn until one accepts the write.
+emit /dev/tty && exit 0
+
+while read -r tty; do
+    emit "$tty" && exit 0
+done < <(find_candidate_ttys)
+
+exit 0

--- a/plugins/warp/tests/test-find-controlling-tty.sh
+++ b/plugins/warp/tests/test-find-controlling-tty.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Tests for find-controlling-tty.sh
+#
+# The function walks up the process tree using `ps`. We override `ps` as a
+# shell function so the tests don't depend on the actual process tree.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)"
+source "$SCRIPT_DIR/find-controlling-tty.sh"
+
+PASSED=0
+FAILED=0
+
+assert_eq() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ $expected == "$actual" ]]; then
+        echo "  ✓ $test_name"
+        PASSED=$((PASSED + 1))
+    else
+        echo "  ✗ $test_name"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+echo "=== find-controlling-tty.sh ==="
+
+echo ""
+echo "--- Emits the parent's tty when it has one ---"
+ps() {
+    case "$*" in
+        "-o tty= -p $PPID")  echo "ttys003" ;;
+        "-o ppid= -p $PPID") echo "1" ;;
+        *) command ps "$@" ;;
+    esac
+}
+result=$(find_candidate_ttys | tr '\n' ' ' | sed 's/ $//')
+assert_eq "parent tty appears as /dev/<name>" "/dev/ttys003" "$result"
+unset -f ps
+
+echo ""
+echo "--- Skips ancestors with no controlling tty, keeps walking ---"
+ps() {
+    case "$*" in
+        "-o tty= -p $PPID")    echo "??" ;;
+        "-o tty= -p 77001")    echo "??" ;;
+        "-o tty= -p 77002")    echo "ttys004" ;;
+        "-o ppid= -p $PPID")   echo "77001" ;;
+        "-o ppid= -p 77001")   echo "77002" ;;
+        "-o ppid= -p 77002")   echo "1" ;;
+        *) command ps "$@" ;;
+    esac
+}
+result=$(find_candidate_ttys | tr '\n' ' ' | sed 's/ $//')
+assert_eq "?? entries are skipped, real tty emitted" "/dev/ttys004" "$result"
+unset -f ps
+
+echo ""
+echo "--- Emits multiple ancestors if more than one has a tty ---"
+# A nested case (e.g. tmux): both inner and outer ancestors have ttys.
+ps() {
+    case "$*" in
+        "-o tty= -p $PPID")    echo "ttys001" ;;
+        "-o tty= -p 88001")    echo "ttys002" ;;
+        "-o ppid= -p $PPID")   echo "88001" ;;
+        "-o ppid= -p 88001")   echo "1" ;;
+        *) command ps "$@" ;;
+    esac
+}
+result=$(find_candidate_ttys | tr '\n' ' ' | sed 's/ $//')
+assert_eq "both ancestor ttys are emitted in order" "/dev/ttys001 /dev/ttys002" "$result"
+unset -f ps
+
+echo ""
+echo "--- Emits nothing when no ancestor has a tty ---"
+ps() {
+    case "$*" in
+        "-o tty="*) echo "??" ;;
+        "-o ppid="*) echo "1" ;;
+        *) command ps "$@" ;;
+    esac
+}
+result=$(find_candidate_ttys)
+assert_eq "no output when every ancestor reports ??" "" "$result"
+unset -f ps
+
+echo ""
+echo "--- Honors depth limit on unbounded process chains ---"
+ps() {
+    case "$*" in
+        "-o tty="*) echo "??" ;;
+        "-o ppid="*) echo "9999" ;;
+        *) command ps "$@" ;;
+    esac
+}
+# Should terminate (not hang) even though every ppid points to a non-init pid.
+start_secs=$SECONDS
+find_candidate_ttys > /dev/null
+elapsed=$((SECONDS - start_secs))
+if (( elapsed <= 2 )); then
+    echo "  ✓ depth-limited walk terminates promptly"
+    PASSED=$((PASSED + 1))
+else
+    echo "  ✗ depth-limited walk took too long (${elapsed}s)"
+    FAILED=$((FAILED + 1))
+fi
+unset -f ps
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+
+if (( FAILED > 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
# Fix notifications when hooks have no controlling tty

## Summary

When the plugin's hooks run inside a sandbox that detaches the subprocess from its controlling terminal, `/dev/tty` becomes unopenable — `open("/dev/tty")` returns ENXIO because the process is in a new session with no controlling tty. Every `printf > /dev/tty` in `warp-notify.sh` then silently fails, so no OSC reaches Warp and the agent indicators (blue dot, in-progress / blocked badges, completion toasts) never show.

The concrete trigger is Claude Code's macOS `sandbox-exec` wrapper for Bash tool calls, opted into via `"sandbox": {"enabled": true}` in `.claude/settings.json` (a sandbox feature it added recently). Other sandboxers (`firejail`, etc.) that detach the controlling tty would hit the same failure.

This PR makes the notify path resilient: when `/dev/tty` is unavailable, walk the process tree and try each ancestor's tty in turn. The first one that accepts the write (typically `claude` itself, which lives in the Warp pane and isn't sandboxed) is used.

Behavior is unchanged for users not running in a tty-detached sandbox.

## Repro

Requires macOS + Claude Code + Warp.

1. Enable Claude Code's bash sandbox in your project's `.claude/settings.json`:
   ```json
   { "sandbox": { "enabled": true } }
   ```
2. Run `claude` inside Warp from that project directory.
3. Send any prompt. The plugin's hooks (`SessionStart`, `Stop`, `Notification`, `UserPromptSubmit`, `PostToolUse`) all fire and call `warp-notify.sh`, but Warp shows no agent indicator and no completion toast.

Instrumenting `warp-notify.sh` to capture the redirection error shows:
```
controlling_tty=??
/dev/tty test: char-device
/dev/tty readable: yes, writable: yes      # the `test` builtin lies — the device node exists
/dev/tty write: rc=1 err='warp-notify.sh: /dev/tty: Device not configured'
```

Writing to the parent process's actual pty (e.g. `/dev/ttys003`) succeeds and Warp displays the indicator.

## Changes

- **New** `plugins/warp/scripts/find-controlling-tty.sh` — exposes `find_candidate_ttys`, which walks `$PPID` upward via `ps -o tty=` / `ps -o ppid=` and prints each ancestor's tty device path (one per line), skipping ancestors with no controlling tty. Depth-capped at 20 hops to bound the walk.
- `plugins/warp/scripts/warp-notify.sh` (structured) — try `/dev/tty` first; on failure, iterate `find_candidate_ttys` and write to each until one accepts the bytes.
- `plugins/warp/scripts/legacy/warp-notify.sh` — same fallback.
- **New** `plugins/warp/tests/test-find-controlling-tty.sh` — 5 cases: direct-parent hit, walk-past-`??`-ancestors, multiple-ancestor emission (nested case), no-tty-anywhere, depth-limit termination. Mocks `ps` as a shell function.

Existing `tests/test-hooks.sh` continues to pass (40/40); new tests add 5 more.

## Caveats

- **Workaround, not root-cause fix.** The proper place to solve this is in Claude Code — either don't sandbox hooks, or expose a non-tty notification channel — but neither is in this plugin's control. Happy to link a Claude Code issue if one's tracked.
- **`ps` cost.** Worst case is 2 calls per hop × 20 hops = 40 `ps` invocations; in practice 2-4 calls. Sub-millisecond on modern hardware.
- **No "is this Warp?" check on ancestors.** In nested setups (tmux, screen, ssh into non-Warp), the OSC may end up in a terminal that ignores it. OSC 777 is widely ignored by terminals that don't implement it, so the worst case is a silently dropped notification rather than corruption.
- **Breaks if Claude Code ever sandboxes its own root process.** The fallback works today because only the bash hook subprocess is sandboxed; `claude` itself runs in the Warp pane and is reachable via the tree walk.
- **`ps -o tty=` output format.** macOS reports `ttys003`, Linux reports `pts/3`; both prefix correctly to `/dev/...`. Not tested on other Unixes (the plugin targets Warp, which is macOS / Linux only).

## Relation to other PRs

- **#19** (open since Apr 15) takes the same general approach — walking the parent chain. This PR factors the walk into a reusable helper so both the structured and legacy `warp-notify.sh` paths share it, emits *all* writable candidates (so a failed write to one ancestor falls through to the next, useful in nested setups), updates both scripts, and adds dedicated unit tests for the helper. Happy to defer to #19 if preferred — flagging this purely so the duplication is visible.
- **#40** (May 12) is a complementary forward-looking change: prefer `WARP_CLI_AGENT_IPC` when Warp exposes it. That env var isn't set on current stable Warp (`v0.2026.05.06.15.42.stable_05`) on my machine, so it doesn't help today, but it's the cleaner long-term channel and this PR would naturally fall back to it once Warp sets it (the `/dev/tty` path still gets tried first; if both fail, the ancestor walk runs).
- **#37** (bounds `/dev/tty` writes against UI hangs) is unrelated but in the same general area.

## Test plan

- [x] `bash plugins/warp/tests/test-hooks.sh` — 40/40 pass
- [x] `bash plugins/warp/tests/test-find-controlling-tty.sh` — 5/5 pass
- [x] Manual: with `sandbox.enabled: true` in `.claude/settings.json`, fresh `claude` in Warp shows agent indicators (blue dot, in-progress badge, completion toast). With sandbox off, behavior is unchanged.
