### PR TITLE
use portable shebang (#!/usr/bin/env bash) for cross-platform compatibility

### DIFF
--- a/plugins/warp/scripts/build-payload.sh
+++ b/plugins/warp/scripts/build-payload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds a structured JSON notification payload for warp://cli-agent.
 #
 # Usage: source this file, then call build_payload with event-specific fields.

--- a/plugins/warp/scripts/legacy/on-notification.sh
+++ b/plugins/warp/scripts/legacy/on-notification.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code Notification event
 # Sends a Warp notification when Claude needs user input
 

--- a/plugins/warp/scripts/legacy/on-session-start.sh
+++ b/plugins/warp/scripts/legacy/on-session-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code SessionStart event
 # Shows welcome message and Warp detection status
 

--- a/plugins/warp/scripts/legacy/on-stop.sh
+++ b/plugins/warp/scripts/legacy/on-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code Stop event
 # Sends a Warp notification when Claude completes a task
 

--- a/plugins/warp/scripts/legacy/warp-notify.sh
+++ b/plugins/warp/scripts/legacy/warp-notify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Warp notification utility using OSC escape sequences
 # Usage: warp-notify.sh <title> <body>
 

--- a/plugins/warp/scripts/on-notification.sh
+++ b/plugins/warp/scripts/on-notification.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code Notification event (idle_prompt only)
 # Sends a structured Warp notification when Claude has been idle
 

--- a/plugins/warp/scripts/on-permission-request.sh
+++ b/plugins/warp/scripts/on-permission-request.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code PermissionRequest event
 # Sends a structured Warp notification when Claude needs permission to run a tool
 

--- a/plugins/warp/scripts/on-post-tool-use.sh
+++ b/plugins/warp/scripts/on-post-tool-use.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code PostToolUse event
 # Sends a structured Warp notification after a tool call completes,
 # transitioning the session status from Blocked back to Running.

--- a/plugins/warp/scripts/on-prompt-submit.sh
+++ b/plugins/warp/scripts/on-prompt-submit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code UserPromptSubmit event
 # Sends a structured Warp notification when the user submits a prompt,
 # transitioning the session status from idle/blocked back to running.

--- a/plugins/warp/scripts/on-session-start.sh
+++ b/plugins/warp/scripts/on-session-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code SessionStart event
 # Shows welcome message, Warp detection status, and emits plugin version
 

--- a/plugins/warp/scripts/on-stop.sh
+++ b/plugins/warp/scripts/on-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook script for Claude Code Stop event
 # Sends a structured Warp notification when Claude completes a task
 

--- a/plugins/warp/scripts/should-use-structured.sh
+++ b/plugins/warp/scripts/should-use-structured.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Determines whether the current Warp build supports structured CLI agent notifications.
 #
 # Usage:

--- a/plugins/warp/scripts/warp-notify.sh
+++ b/plugins/warp/scripts/warp-notify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Warp notification utility using OSC escape sequences
 # Usage: warp-notify.sh <title> <body>
 #

--- a/plugins/warp/tests/test-hooks.sh
+++ b/plugins/warp/tests/test-hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Tests for the Warp Claude Code plugin hook scripts.
 #
 # Validates that each hook script produces correctly structured JSON payloads


### PR DESCRIPTION
All 14 shell scripts use #!/bin/bash as their shebang, which assumes bash is located at /bin/bash. This path doesn't exist on at least NixOS.

Replaced all shebangs with `#!/usr/bin/env bash`, which resolves bash via `$PATH`. This is the recommended portable approach for shell scripts.

### Changes
- Updated shebang from `#!/bin/bash` to `#!/usr/bin/env bash` in all 14 scripts under plugins/warp/

No functional changes — only the interpreter lookup method is affected.