### PR TITLE
fix: resolve controlling TTY for hook processes without /dev/tty

### DIFF
--- a/plugins/warp/scripts/legacy/warp-notify.sh
+++ b/plugins/warp/scripts/legacy/warp-notify.sh
@@ -2,9 +2,13 @@
 # Warp notification utility using OSC escape sequences
 # Usage: warp-notify.sh <title> <body>
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../resolve-tty.sh"
+
 TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+# Hook processes have no controlling terminal, so resolve the real tty of an
+# ancestor process rather than relying on /dev/tty (which fails in that case).
+printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > "$(resolve_tty_device)" 2>/dev/null || true

--- a/plugins/warp/scripts/resolve-tty.sh
+++ b/plugins/warp/scripts/resolve-tty.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Resolve the terminal device to write OSC escape sequences to.
+#
+# Claude Code spawns hook processes WITHOUT a controlling terminal, so the
+# usual `/dev/tty` is unavailable ("Device not configured" / ENXIO) and any
+# notification written there is silently dropped. Walk up the process tree
+# to find an ancestor (the `claude` process or its parent shell) that still
+# has a controlling tty, and return that device node instead.
+#
+# Falls back to `/dev/tty` when no ancestor with a tty is found, so callers
+# behave exactly as before in environments where `/dev/tty` already works.
+#
+# Usage:
+#   source "$SCRIPT_DIR/resolve-tty.sh"
+#   printf '...' > "$(resolve_tty_device)"
+
+resolve_tty_device() {
+    local pid=$PPID depth=0 tty_name
+    while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$depth" -lt 25 ]; do
+        # `ps -o tty=` prints e.g. `ttys003` (macOS) or `pts/3` (Linux),
+        # and `?` / `??` for a process with no controlling terminal.
+        tty_name=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+        case "$tty_name" in
+            '' | '?' | '??')
+                : # this ancestor has no controlling tty — keep walking up
+                ;;
+            *)
+                printf '/dev/%s\n' "$tty_name"
+                return 0
+                ;;
+        esac
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+        depth=$((depth + 1))
+    done
+    printf '/dev/tty\n'
+}

--- a/plugins/warp/scripts/warp-notify.sh
+++ b/plugins/warp/scripts/warp-notify.sh
@@ -7,6 +7,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/should-use-structured.sh"
+source "$SCRIPT_DIR/resolve-tty.sh"
 
 # Only emit notifications when we've confirmed the Warp build can render them.
 if ! should_use_structured; then
@@ -17,5 +18,6 @@ TITLE="${1:-Notification}"
 BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
-# Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+# Hook processes have no controlling terminal, so resolve the real tty of an
+# ancestor process rather than relying on /dev/tty (which fails in that case).
+printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > "$(resolve_tty_device)" 2>/dev/null || true


### PR DESCRIPTION
## Problem

Claude Code spawns hook processes **without a controlling terminal**. Both
`warp-notify.sh` scripts emit the OSC 777 sequence with `printf … > /dev/tty`,
which fails in that context — so Warp never receives any cli-agent event
(no notifications, no status, no footer).

### Diagnosis

Instrumenting `warp-notify.sh` to record its runtime context when invoked by a
real hook (`UserPromptSubmit` / `PostToolUse` / `Stop`):

```
=== warp-notify.sh — invoked by a Claude Code hook ===
tty:                     not a tty          # hook has no controlling terminal
parent process:          /bin/bash          # ... and neither does its parent
WARP_CLI_AGENT_PROTOCOL_VERSION=1
should_use_structured:   YES                # the plugin wants to emit
/dev/tty:                Device not configured
printf > /dev/tty:       exit=1             # OSC 777 silently dropped
```

`should-use-structured` passes (Warp advertises protocol support), so the
plugin *intends* to send — but the `/dev/tty` write fails with `ENXIO`
because the hook process is not attached to any controlling terminal, and the
notification is lost.

(The repo is already aware `/dev/tty` isn't always available — `tests/test-hooks.sh`
overrides `/dev/tty` writes "since they'd fail in CI" — but the runtime hook
path was never given the same treatment.)

## Fix

New shared helper `scripts/resolve-tty.sh`: walk up the process tree from
`$PPID` to the first ancestor that still has a controlling tty (the `claude`
process / its parent shell) and write the OSC sequence to that device node.
Falls back to `/dev/tty` when no ancestor tty is found, so the change is
strictly additive — environments where `/dev/tty` already works are unaffected.

Both `scripts/warp-notify.sh` and `scripts/legacy/warp-notify.sh` route through it.

## Testing

- `bash -n` on all three scripts.
- With the diagnostic above: **before** — `printf` exits 1, nothing reaches the
  terminal; **after** — the hook resolves the real PTY (`/dev/ttysNNN`), the
  `printf` succeeds (exit 0), and the terminal receives and parses the
  cli-agent OSC 777 event.
- Reproduced on macOS with Claude Code v2.1.143. The root cause is in how
  Claude Code spawns hook processes (no controlling terminal) — independent of
  the terminal app — so it should affect current Claude Code generally;
  maintainers, please confirm against your environment.
