### PR TITLE
fix(warp): run hook scripts through bash on Windows

### DIFF
--- a/plugins/warp/hooks/hooks.json
+++ b/plugins/warp/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-session-start.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/on-session-start.sh\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.sh\""
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-notification.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/on-notification.sh\""
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-permission-request.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/on-permission-request.sh\""
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/on-prompt-submit.sh\""
           }
         ]
       }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-post-tool-use.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/on-post-tool-use.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Invoke Warp hook shell scripts through `bash` in `hooks.json`
- Prevent native Windows Claude Code from asking which app should open `.sh` files when hooks run

Closes #56

## Verification

- `Get-Content -Raw plugins\warp\hooks\hooks.json | ConvertFrom-Json | Out-Null`
- `git diff --check`
- Simulated `on-post-tool-use.sh` invocation through Bash exits successfully in local Windows environment

Note: `bash plugins/warp/tests/test-hooks.sh` currently reports 55 passed / 2 failed on Windows Git Bash because test fixture paths like `/Users/alice/my-project` and `/tmp/transcript.jsonl` are auto-converted to `C:/Program Files/Git/...` and `C:/Users/Administrator/AppData/Local/Temp/...`. Those failures appear unrelated to this hook command change.
