### PR TITLE
fix(warp): skip synthetic system messages when picking last user prompt

### DIFF
--- a/plugins/warp/scripts/on-stop.sh
+++ b/plugins/warp/scripts/on-stop.sh
@@ -32,22 +32,22 @@ RESPONSE=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     # Get the last human prompt from the transcript.
     # "user" type messages include both human prompts and tool-result messages.
-    # Human prompts have content that is either a plain string or an array
-    # containing {type:"text"} blocks. Tool-result messages have content arrays
-    # containing only {type:"tool_result"} blocks. We filter to messages that
-    # have at least one "text" block (or are a plain string).
+    # We extract the joined text from each user message, then skip messages whose
+    # content is a synthetic system-injected tag (task-notification when a
+    # background subagent completes, system-reminder, slash-command wrappers, etc.).
+    # Without this filter, those raw XML payloads end up as the notification title.
     QUERY=$(jq -rs '
         [
             .[] | select(.type == "user") |
-            if .message.content | type == "string" then .
-            elif [.message.content[] | select(.type == "text")] | length > 0 then .
-            else empty
-            end
-        ] | last |
-        if .message.content | type == "array"
-        then [.message.content[] | select(.type == "text") | .text] | join(" ")
-        else .message.content // empty
-        end
+            (if .message.content | type == "string" then .message.content
+             elif .message.content | type == "array" then
+                 ([.message.content[]? | select(.type == "text") | .text] | join(" "))
+             else empty
+             end) as $text |
+            select(($text | length) > 0) |
+            select($text | test("^\\s*<(task-notification|system-reminder|command-message|command-name|command-args|local-command-stdout|user-prompt-submit-hook)\\b") | not) |
+            $text
+        ] | last // empty
     ' "$TRANSCRIPT_PATH" 2>/dev/null)
 
     # Get the last assistant response


### PR DESCRIPTION
## Problem

When a background subagent finishes, Claude Code injects a synthetic *user-type* message into the transcript whose text content is a raw XML payload like:

```
<task-notification>
<task-id>a7a64d8bab99c279b</task-id>
<output-file>/private/tmp/claude-501/.../out.json</output-file>
</task-notification>
```

The Stop hook's QUERY extraction picks the last text-bearing `user` message unconditionally, so this raw payload ends up as the notification title in Warp. From the user's perspective it looks like the plugin is leaking internal tags into the notification.

Screenshot of the bug (two notifications, both showing raw `<task-notification>` XML as the title): https://github.com/user-attachments/assets/ (described by reporter — happens consistently when running a background subagent that completes after the foreground turn ends).

The same class of synthetic messages includes `<system-reminder>` (sporadic harness reminders), slash-command wrappers (`<command-message>`, `<command-name>`, `<command-args>`), local bash output (`<local-command-stdout>`), and the prompt-submit hook tag (`<user-prompt-submit-hook>`).

## Fix

Restructure the jq selector in `on-stop.sh` to:

1. Compute the joined text content of each `user` message up front.
2. Skip messages where that text starts with a known synthetic tag (regex `^\s*<(task-notification|system-reminder|command-message|command-name|command-args|local-command-stdout|user-prompt-submit-hook)\b`).
3. Take `last` of what remains — the real most-recent user prompt.

Functionally equivalent for normal sessions (no synthetic injections in the tail). For sessions containing the injections, the title falls through to the previous real user prompt instead of the XML payload.

## Verified locally

```sh
# Synthesized transcript ending in a <task-notification> message:
QUERY="please run the qa-portal sweep in the background"   # ✓ real prompt
RESPONSE="Task completed."                                 # ✓ unchanged
```

Before the fix, `QUERY` was the raw `<task-notification>...</task-notification>` blob.

## Scope

- Only `plugins/warp/scripts/on-stop.sh` touched.
- `on-permission-request.sh`, `on-post-tool-use.sh`, `on-prompt-submit.sh`, `on-notification.sh` read directly from hook stdin (never the transcript), so they're unaffected.
- No behavior change for assistants (`RESPONSE` extraction untouched).