### PR TITLE
fix(warp): remove unsupported hooks description

### DIFF
--- a/plugins/warp/hooks/hooks.json
+++ b/plugins/warp/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Warp terminal notifications",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
- Remove the top-level `description` field from the Warp plugin hooks config.
- Keep the config schema limited to the `hooks` field expected by the plugin hook parser.

## Testing
- `jq . plugins/warp/hooks/hooks.json`
- `bash plugins/warp/tests/test-hooks.sh`