### PR TITLE
Add StopFailure hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "warp",
       "description": "Native Warp notifications when Claude completes tasks or needs input",
       "source": "./plugins/warp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "category": "productivity",
       "tags": ["notifications", "terminal", "warp"]
     },

--- a/plugins/warp/.claude-plugin/plugin.json
+++ b/plugins/warp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "warp",
   "description": "Warp terminal integration for Claude Code - native notifications, and more to come",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": {
     "name": "Warp",
     "url": "https://warp.dev"

--- a/plugins/warp/hooks/hooks.json
+++ b/plugins/warp/hooks/hooks.json
@@ -62,6 +62,16 @@
           }
         ]
       }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-stop-failure.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/warp/scripts/on-stop-failure.sh
+++ b/plugins/warp/scripts/on-stop-failure.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Hook script for Claude Code StopFailure event
+# Sends a structured Warp notification when Claude's turn ends due to an API error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/should-use-structured.sh"
+
+# Legacy Warp clients that don't support structured events don't get a
+# stop_failure notification — they have no UI to act on it.
+if ! should_use_structured; then
+    exit 0
+fi
+
+source "$SCRIPT_DIR/build-payload.sh"
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Try to extract an error message from the hook input.
+# Claude Code may surface the error under different field names depending on
+# the version, so check the most likely candidates.
+ERROR_MESSAGE=$(echo "$INPUT" | jq -r '
+    .error_message // .error // .message // empty
+' 2>/dev/null)
+
+# Also try to extract the last user query from the transcript so Warp can
+# show it as the notification title, matching the Stop hook behaviour.
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+QUERY=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    QUERY=$(jq -rs '
+        [
+            .[] | select(.type == "user") |
+            if .message.content | type == "string" then .
+            elif [.message.content[] | select(.type == "text")] | length > 0 then .
+            else empty
+            end
+        ] | last |
+        if .message.content | type == "array"
+        then [.message.content[] | select(.type == "text") | .text] | join(" ")
+        else .message.content // empty
+        end
+    ' "$TRANSCRIPT_PATH" 2>/dev/null)
+
+    if [ -n "$QUERY" ] && [ ${#QUERY} -gt 200 ]; then
+        QUERY="${QUERY:0:197}..."
+    fi
+fi
+
+BODY=$(build_payload "$INPUT" "stop_failure" \
+    --arg query "$QUERY" \
+    --arg response "$ERROR_MESSAGE" \
+    --arg transcript_path "$TRANSCRIPT_PATH")
+
+"$SCRIPT_DIR/warp-notify.sh" "warp://cli-agent" "$BODY"

--- a/plugins/warp/scripts/on-stop-failure.sh
+++ b/plugins/warp/scripts/on-stop-failure.sh
@@ -16,12 +16,9 @@ source "$SCRIPT_DIR/build-payload.sh"
 # Read hook input from stdin
 INPUT=$(cat)
 
-# Try to extract an error message from the hook input.
-# Claude Code may surface the error under different field names depending on
-# the version, so check the most likely candidates.
-ERROR_MESSAGE=$(echo "$INPUT" | jq -r '
-    .error_message // .error // .message // empty
-' 2>/dev/null)
+# Extract the error type (e.g. "rate_limit") and human-readable message.
+ERROR_TYPE=$(echo "$INPUT" | jq -r '.error // empty' 2>/dev/null)
+ERROR_MESSAGE=$(echo "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null)
 
 # Also try to extract the last user query from the transcript so Warp can
 # show it as the notification title, matching the Stop hook behaviour.
@@ -50,6 +47,7 @@ fi
 BODY=$(build_payload "$INPUT" "stop_failure" \
     --arg query "$QUERY" \
     --arg response "$ERROR_MESSAGE" \
+    --arg error_type "$ERROR_TYPE" \
     --arg transcript_path "$TRANSCRIPT_PATH")
 
 "$SCRIPT_DIR/warp-notify.sh" "warp://cli-agent" "$BODY"


### PR DESCRIPTION
Resolves https://linear.app/warpdotdev/issue/REMOTE-1997/oz-shows-claude-code-run-as-running-after-anthropic-api-500-error

Claude code has a hook on failures that warp can use. See https://code.claude.com/docs/en/hooks#stopfailure

This extracts the error and last_assistant_message fields

## Testing

Tested locally with https://github.com/warpdotdev/warp/pull/13784

Run claude code with invalid model and using local plugin build:
`ANTHROPIC_MODEL=claude-4-8-opus-high claude --plugin-dir ~/claude-code-warp/plugins/warp`

Send a query, see a log in warp
```
12:45:03.758 [INFO] [warp::terminal::model::ansi] Received OSC 777 notification: title=Some("warp://cli-agent"), body={"v":1,"agent":"claude","event":"stop_failure","session_id":"8c574469-befe-4e9a-802a-6e3350ab2f5a","cwd":"/Users/rolandhuang","project":"rolandhuang","query":"here is another test","response":"There's an issue with the selected model (claude-4-8-opus-high). It may not exist or you may not have access to it. Run /model to pick a different model.","error_type":"model_not_found","transcript_path":"/Users/rolandhuang/.claude/projects/-Users-rolandhuang/8c574469-befe-4e9a-802a-6e3350ab2f5a.jsonl"}
```