### PR TITLE
fix(warp): stop /dev/tty ENXIO error leaking to the user

### DIFF
--- a/plugins/warp/scripts/emit-terminal-sequence.sh
+++ b/plugins/warp/scripts/emit-terminal-sequence.sh
@@ -72,14 +72,24 @@ emit_terminal_sequence() {
             # Known-old Claude Code — /dev/tty is the only safe path.
             # Emitting terminalSequence here would be rejected by the Stop
             # hook validator as an unknown field.
-            printf '%s' "$seq" > /dev/tty 2>/dev/null || true
+            #
+            # The write is wrapped in a brace group before the redirect to
+            # /dev/null: when there's no controlling terminal, opening
+            # /dev/tty fails with ENXIO ("Device not configured") and bash
+            # reports that itself, to the *original* stderr — a bare
+            # `> /dev/tty 2>/dev/null` can't catch it because the failing
+            # redirect is set up before the `2>/dev/null` one. Grouping
+            # applies 2>/dev/null to the whole group first.
+            { printf '%s' "$seq" > /dev/tty; } 2>/dev/null || true
         fi
         return 0
     fi
 
     # Unknown Claude Code version — try /dev/tty, fall back to JSON
     # as a best-effort attempt for new CC without version detection.
-    if printf '%s' "$seq" > /dev/tty 2>/dev/null; then
+    # See the brace-group note above: it's needed here too, otherwise a
+    # missing controlling terminal leaks a raw bash error to the user.
+    if { printf '%s' "$seq" > /dev/tty; } 2>/dev/null; then
         return 0
     fi
     jq -nc --arg seq "$seq" '{terminalSequence: $seq}'


### PR DESCRIPTION
## Summary

- `emit-terminal-sequence.sh` writes to `/dev/tty` as a fallback when `CLAUDE_CODE_VERSION` can't be resolved (e.g. during `SessionStart`, before the version-detection env caching kicks in). When the hook subprocess has no controlling terminal, opening `/dev/tty` fails with `ENXIO`, and bash reports `"line N: /dev/tty: Device not configured"` itself — to the *original* stderr, before the script's own `2>/dev/null` on that same command takes effect. The result is a raw bash error printed to the user on session start, even though the script goes on to correctly fall back to the `terminalSequence` JSON output.
- Fix: wrap the write in a brace group before applying `2>/dev/null`, so the suppression covers the whole group (including the redirect's own open failure) rather than trying to suppress errors on a redirect that fails before the following one applies.
- No behavior change otherwise — return codes and the JSON fallback path are identical.

## Repro

```
$ bash -c 'printf hi > /dev/tty 2>/dev/null'
bash: line 1: /dev/tty: Device not configured   # leaks despite 2>/dev/null

$ bash -c '{ printf hi > /dev/tty; } 2>/dev/null'
# (nothing — cleanly suppressed)
```

Before/after against this repo's `emit_terminal_sequence`, no controlling tty, unset `CLAUDE_CODE_VERSION`:

```
# before
./emit-terminal-sequence.sh: line 82: /dev/tty: Device not configured
{"terminalSequence":"test-seq"}

# after
{"terminalSequence":"test-seq"}
```

## Test plan

- [x] `plugins/warp/tests/test-hooks.sh`: 57/57 passing, unchanged
- [x] Manual before/after repro (above) confirming the leaked error is gone and the JSON fallback output is unchanged