### PR TITLE
feat(warp): allow registering alternate CLI agents via WARP_CLI_AGENT_NAME

### DIFF
--- a/plugins/warp/scripts/build-payload.sh
+++ b/plugins/warp/scripts/build-payload.sh
@@ -27,6 +27,11 @@ negotiate_protocol_version() {
     fi
 }
 
+# Agent slug reported to Warp in the payload's `agent` field. Defaults to
+# "claude" (Claude Code). Harnesses that reuse these hook scripts under a
+# different CLI agent — e.g. plank (https://github.com/aovestdipaperino/plank),
+# which speaks the same warp://cli-agent protocol — set WARP_CLI_AGENT_NAME
+# to their own slug so Warp attributes sessions and notifications correctly.
 build_payload() {
     local input="$1"
     local event="$2"
@@ -48,7 +53,7 @@ build_payload() {
     # Extra args should be jq flag pairs like: --arg key "value" or --argjson key '{"a":1}'
     jq -nc \
         --argjson v "$protocol_version" \
-        --arg agent "claude" \
+        --arg agent "${WARP_CLI_AGENT_NAME:-claude}" \
         --arg event "$event" \
         --arg session_id "$session_id" \
         --arg cwd "$cwd" \

--- a/plugins/warp/tests/test-hooks.sh
+++ b/plugins/warp/tests/test-hooks.sh
@@ -54,6 +54,13 @@ echo "--- Common fields ---"
 PAYLOAD=$(build_payload '{"session_id":"sess-123","cwd":"/Users/alice/my-project"}' "stop")
 assert_json_field "v is 1" "$PAYLOAD" ".v" "1"
 assert_json_field "agent is claude" "$PAYLOAD" ".agent" "claude"
+
+echo ""
+echo "--- Agent slug override ---"
+PAYLOAD=$(WARP_CLI_AGENT_NAME=plank build_payload '{"session_id":"sess-123","cwd":"/Users/alice/my-project"}' "stop")
+assert_json_field "agent honors WARP_CLI_AGENT_NAME" "$PAYLOAD" ".agent" "plank"
+PAYLOAD=$(WARP_CLI_AGENT_NAME= build_payload '{"session_id":"sess-123","cwd":"/Users/alice/my-project"}' "stop")
+assert_json_field "empty WARP_CLI_AGENT_NAME falls back to claude" "$PAYLOAD" ".agent" "claude"
 assert_json_field "event is stop" "$PAYLOAD" ".event" "stop"
 assert_json_field "session_id extracted" "$PAYLOAD" ".session_id" "sess-123"
 assert_json_field "cwd extracted" "$PAYLOAD" ".cwd" "/Users/alice/my-project"


### PR DESCRIPTION
## Summary

`build-payload.sh` hard-codes the payload's `agent` slug to `"claude"`, so any harness that reuses these hook scripts is mislabeled in Warp's session UI and notifications.

This PR reads the slug from `WARP_CLI_AGENT_NAME` (defaulting to `claude`, so existing behavior is unchanged) so agents that speak the same `warp://cli-agent` OSC 777 protocol — e.g. [plank](https://github.com/aovestdipaperino/plank) — can register under their own identity.

## Changes
- `plugins/warp/scripts/build-payload.sh`: agent slug from `WARP_CLI_AGENT_NAME`, default `claude`
- `plugins/warp/tests/test-hooks.sh`: assert the override works and that an empty value falls back to `claude`

## Testing
`./plugins/warp/tests/test-hooks.sh` — 59 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)