### PR TITLE
fix: silence /dev/tty redirect errors when no tty is attached

### DIFF
--- a/plugins/warp/scripts/emit-terminal-sequence.sh
+++ b/plugins/warp/scripts/emit-terminal-sequence.sh
@@ -72,14 +72,14 @@ emit_terminal_sequence() {
             # Known-old Claude Code — /dev/tty is the only safe path.
             # Emitting terminalSequence here would be rejected by the Stop
             # hook validator as an unknown field.
-            printf '%s' "$seq" > /dev/tty 2>/dev/null || true
+            printf '%s' "$seq" 2>/dev/null > /dev/tty || true
         fi
         return 0
     fi
 
     # Unknown Claude Code version — try /dev/tty, fall back to JSON
     # as a best-effort attempt for new CC without version detection.
-    if printf '%s' "$seq" > /dev/tty 2>/dev/null; then
+    if printf '%s' "$seq" 2>/dev/null > /dev/tty; then
         return 0
     fi
     jq -nc --arg seq "$seq" '{terminalSequence: $seq}'

--- a/plugins/warp/scripts/legacy/warp-notify.sh
+++ b/plugins/warp/scripts/legacy/warp-notify.sh
@@ -7,4 +7,4 @@ BODY="${2:-}"
 
 # OSC 777 format: \033]777;notify;<title>;<body>\007
 # Write directly to /dev/tty to ensure it reaches the terminal
-printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" > /dev/tty 2>/dev/null || true
+printf '\033]777;notify;%s;%s\007' "$TITLE" "$BODY" 2>/dev/null > /dev/tty || true


### PR DESCRIPTION
## Problem

On Windows / Git Bash the Stop hook runs without a controlling terminal, so every turn prints:

```
/c/Users/<user>/.claude/plugins/cache/claude-code-warp/warp/2.2.0/scripts/emit-terminal-sequence.sh: line 82: /dev/tty: No such device or address
```

The `2>/dev/null` was meant to suppress this, but shell redirections are applied left to right. In `> /dev/tty 2>/dev/null`, the shell opens `/dev/tty` while stderr is still the inherited one, so the failed-open message escapes before `2>/dev/null` takes effect.

## Fix

Swap the order to `2>/dev/null > /dev/tty` so stderr is muted before the open is attempted.

```bash
$ ( printf 'x' > /dev/tty 2>/dev/null ) ; echo "exit=$?"
bash: line 1: /dev/tty: No such device or address
exit=1

$ ( printf 'x' 2>/dev/null > /dev/tty ) ; echo "exit=$?"
exit=1
```

Exit status is unchanged, so the `if` in `emit_terminal_sequence` still falls through to the JSON path correctly.

## Verification

All three branches of `emit_terminal_sequence` exercised with no tty attached:

| `CLAUDE_CODE_VERSION` | Output | stderr |
| --- | --- | --- |
| unset (unknown) | `{"terminalSequence":"HELLO"}` | clean |
| `2.5.0` (new) | `{"terminalSequence":"HELLO"}` | clean |
| `2.0.0` (old, tty path) | none, exit 0 | clean |

`bash -n` passes on both files. Same one-line change applied to `legacy/warp-notify.sh`, which has the identical pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWTCPGfRHRHJxiuXUjxP6X
